### PR TITLE
fix for specdm to allow weapons

### DIFF
--- a/lua/terrortown/entities/roles/shinigami/shared.lua
+++ b/lua/terrortown/entities/roles/shinigami/shared.lua
@@ -84,6 +84,7 @@ if SERVER then
 	end)
 
 	hook.Add("PlayerCanPickupWeapon", "TTTShinigamiPickupWeapon", function(ply, wep)
+		if SpecDM and (ply.IsGhost and ply:IsGhost()) then return end
 		if ply:GetSubRole() == ROLE_SHINIGAMI and ply:GetNWBool("SpawnedAsShinigami") and WEPS.GetClass(wep) ~= "weapon_ttt_shinigamiknife" then
 			return false
 		end


### PR DESCRIPTION
Tested with and without specdm installed on the newest ttt2 version.
This fixes the problem where the shinigami gets no weapons in specdm.