### PR TITLE
Added subrole check to speed modifier

### DIFF
--- a/lua/terrortown/entities/roles/shinigami/shared.lua
+++ b/lua/terrortown/entities/roles/shinigami/shared.lua
@@ -148,7 +148,7 @@ if SERVER then
 end
 
 hook.Add("TTTPlayerSpeedModifier", "ShinigamiModifySpeed", function(ply, _, _, noLag)
-	if not IsValid(ply) or not ply:GetNWBool("SpawnedAsShinigami") then return end
+	if not IsValid(ply) or not ply:GetNWBool("SpawnedAsShinigami") or ply:GetSubRole() ~= ROLE_SHINIGAMI then return end
 
 	noLag[1] = noLag[1] * GetGlobalFloat("ttt2_shinigami_speed", 2)
 end)


### PR DESCRIPTION
Fixes bug where a shinigami who is revived after "awakening" retains their increased speed.