### PR TITLE
Fixed ttt_radio hooks

### DIFF
--- a/lua/terrortown/entities/roles/shinigami/shared.lua
+++ b/lua/terrortown/entities/roles/shinigami/shared.lua
@@ -169,7 +169,9 @@ if SERVER then
 
 	-- prevent radio commands
 	hook.Add("TTTPlayerRadioCommand", "TTT2ModifyQuickChat4Shini", function(ply, msg_name, msg_target)
-		return ply:GetNWBool("SpawnedAsShinigami", false)
+		if ply:GetNWBool("SpawnedAsShinigami", false) then
+			return true
+		end
 	end)
 end
 
@@ -186,5 +188,7 @@ hook.Add("TTT2CanUseVoiceChat", "TTT2ModifyGeneralVoiceChat4Shini", function(spe
 end)
 
 hook.Add("TTT2ClientRadioCommand", "TTT2ModifyQuickChat4Shini", function()
-	return LocalPlayer():GetNWBool("SpawnedAsShinigami", false)
+	if LocalPlayer():GetNWBool("SpawnedAsShinigami", false) then
+		return true
+	end
 end)


### PR DESCRIPTION
The two hooks that can disable ttt_radio (TTTPlayerRadioCommand and TTT2ClientRadioCommand) would always return a boolean, which prevents similar hooks from other addons from running (and potentially disabling ttt_radio for other reasons). This commit should fix that by only returning true (which disables ttt_radio) when SpawnedAsShinigami is true.