### PR TITLE
Fixed Shinigami not resetting on role switch.

### DIFF
--- a/lua/terrortown/entities/roles/shinigami/shared.lua
+++ b/lua/terrortown/entities/roles/shinigami/shared.lua
@@ -94,6 +94,7 @@ if SERVER then
 	hook.Add("TTTEndRound", "ResetShinigami", ResetShinigami)
 	hook.Add("TTTPrepareRound", "ResetShinigami", ResetShinigami)
 	hook.Add("TTTBeginRound", "ResetShinigami", ResetShinigami)
+	hook.Add("TTT2UpdateSubrole", "ResetShinigami", ResetShinigami)
 
 	hook.Add("TTT2PostPlayerDeath", "OnShinigamiDeath", function(victim, inflictor, attacker)
 		if victim:GetSubRole() == ROLE_SHINIGAMI and not victim:GetNWBool("SpawnedAsShinigami") and not victim.reviving then


### PR DESCRIPTION
So when the Shinigami is respawned and then swaps their role, previously they were still considered "SpawnedAsShinigami" blocking them from using the Radio Commands or Chat for example.