### PR TITLE
Fixed **any** Subrole change changing the shinigami state

### DIFF
--- a/lua/terrortown/entities/roles/shinigami/shared.lua
+++ b/lua/terrortown/entities/roles/shinigami/shared.lua
@@ -94,7 +94,9 @@ if SERVER then
 	hook.Add("TTTEndRound", "ResetShinigami", ResetShinigami)
 	hook.Add("TTTPrepareRound", "ResetShinigami", ResetShinigami)
 	hook.Add("TTTBeginRound", "ResetShinigami", ResetShinigami)
-	hook.Add("TTT2UpdateSubrole", "ResetShinigami", ResetShinigami)
+	hook.Add("TTT2UpdateSubrole", "ResetShinigami", function(ply, oldSubRole, newSubRole)
+		ply:SetNWBool("SpawnedAsShinigami", false)
+	end)
 
 	hook.Add("TTT2PostPlayerDeath", "OnShinigamiDeath", function(victim, inflictor, attacker)
 		if victim:GetSubRole() == ROLE_SHINIGAMI and not victim:GetNWBool("SpawnedAsShinigami") and not victim.reviving then


### PR DESCRIPTION
Hey it's me again!

Yesterday I accidentally introduced a bug into the Shinigami for which I want to apologize. The way I implemented the role check was naive.
As I for some reason expected the "ResetShinigami" function to only run for the player that is currently switching the role.
That unfortunately is not the case and instead currently the flow is like this:
Shinigami spawns as Innocent → dies → revives → **anyone** changes their role and **all** players spawned as a Shinigami loose their "SpawnedAsShinigami" state which causes them to keep the knife and not take anymore tick damage.

This is fixed by actually using the player that is send via the TTT2UpdateSubrole hook instead of using the ResetShinigami function, which iterates over all players. I have tested this case and the bug is not occurring any more.

Again I am sorry for not realizing this earlier.