### PR TITLE
Spawn Location, Last Words and Revive Time

### DIFF
--- a/lua/terrortown/entities/roles/shinigami/shared.lua
+++ b/lua/terrortown/entities/roles/shinigami/shared.lua
@@ -238,12 +238,10 @@ elseif SERVER then
 		return false
 	end)
 
-	hook.Add("TTT2AvoidLastWords", "TTT2ModifyGeneralChat4Shini", function(ply, text)
+	hook.Add("TTTLastWordsMsg", "TTT2ModifyLastWords4Shini", function(ply, msg, msgOriginal)
 		if not IsValid(ply) or ply:GetSubRole() ~= ROLE_SHINIGAMI or not ply:GetNWBool("SpawnedAsShinigami") then return end
 
-		LANG.Msg(ply, "ttt2_shinigami_chat_jammed", nil, MSG_CHAT_WARN)
-
-		return false
+		return true
 	end)
 
 	hook.Add("TTTOnCorpseCreated", "ModifyShiniRagdoll", function(rag, ply)

--- a/lua/terrortown/entities/roles/shinigami/shared.lua
+++ b/lua/terrortown/entities/roles/shinigami/shared.lua
@@ -1,88 +1,91 @@
-if SERVER then
+if CLIENT then
+	-- Role functions
+	function ROLE:AddToSettingsMenu(parent)
+		local form = vgui.CreateTTT2Form(parent, "header_roles_additional")
+
+		form:MakeCheckBox({
+		serverConvar = "ttt2_shini_needs_corpse",
+		label = "label_shinigami_needs_corpse"
+		})
+
+		form:MakeCheckBox({
+			serverConvar = "ttt2_shini_allow_key_respawn",
+			label = "label_shinigami_allow_key_respawn"
+		})
+
+		form:MakeSlider({
+			serverConvar = "ttt2_shini_revive_time",
+			label = "label_shinigami_revive_time",
+			min = 0,
+			max = 10,
+			decimal = 0
+		})
+
+		form:MakeCheckBox({
+			serverConvar = "ttt2_shinigami_announcement",
+			label = "label_shinigami_announcement"
+		})
+
+		form:MakeSlider({
+			serverConvar = "ttt2_shinigami_speed",
+			label = "label_shinigami_speed",
+			min = 0,
+			max = 5,
+			decimal = 2
+		})
+
+		form:MakeSlider({
+			serverConvar = "ttt2_shinigami_health_loss",
+			label = "label_shinigami_health_loss",
+			min = 0,
+			max = 100,
+			decimal = 0
+		})
+	end
+
+	-- Hooks
+	hook.Add("Initialize", "TTT_Shini_KeyBinds", function()
+		-- Register keybinds
+
+		bind.Register("ttt_shini_respawn_corpse", function()
+			net.Start("ttt_shini_key_respawn")
+			net.WriteBool(true)
+			net.SendToServer()
+		end, nil, "Roles", "Shinigami - Respawn at corpse", corpseKey or KEY_R)
+
+		bind.Register("ttt_shini_respawn_spawn", function()
+			net.Start("ttt_shini_key_respawn")
+			net.WriteBool(false)
+			net.SendToServer()
+		end, nil, "Roles", "Shinigami - Respawn at spawn", spawnKey or KEY_SPACE)
+	end)
+
+	-- Network listeners
+	net.Receive("ttt_shini_show_reason", function(len, ply)
+		-- Get strings for keybinds, this is the same logic as in the addon "A Second Chance"
+		corpseKey = bind.Find("ttt_shini_respawn_corpse") == KEY_NONE and "NONE" or string.upper(input.GetKeyName(bind.Find("ttt_shini_respawn_corpse")))
+		spawnKey = bind.Find("ttt_shini_respawn_spawn") == KEY_NONE and "NONE" or string.upper(input.GetKeyName(bind.Find("ttt_shini_respawn_spawn")))
+
+		LocalPlayer():SetRevivalReason("ttt2_shinigami_revive_keys", {keycorpse = corpseKey, keyspawn = spawnKey})
+	end)
+elseif SERVER then
+	-- Init
 	AddCSLuaFile()
-
 	resource.AddFile("materials/vgui/ttt/dynamic/roles/icon_shini.vmt")
-end
 
-function ROLE:PreInitialize()
-	self.color = Color(200, 200, 200, 255)
+	-- NetworkStrings
+	util.AddNetworkString("ttt_shini_key_respawn")
+	util.AddNetworkString("ttt_shini_show_reason")
 
-	self.abbr = "shini"
-	self.score.killsMultiplier = 2
-	self.score.teamKillsMultiplier = -8
-	self.unknownTeam = true
-	self.disableSync = true
-
-	self.defaultTeam = TEAM_INNOCENT
-	self.defaultEquipment = INNO_EQUIPMENT
-
-	self.conVarData = {
-		pct = 0.15,
-		maximum = 1,
-		minPlayers = 6,
-		credits = 0,
-		togglable = false,
-		random = 50
-	}
-end
-
-function ROLE:Initialize()
-	roles.SetBaseRole(self, ROLE_INNOCENT)
-end
-
-function ROLE:RemoveRoleLoadout(ply, isRoleChange)
-	-- give back normal player loadout
-	ply:GiveEquipmentWeapon("weapon_zm_improvised")
-	ply:GiveEquipmentWeapon("weapon_zm_carry")
-	ply:GiveEquipmentWeapon("weapon_ttt_unarmed")
-
-	ply:StripWeapon("weapon_ttt_shinigamiknife")
-end
-
-hook.Add("TTTUlxDynamicRCVars", "TTTUlxDynamicShiniCVars", function(tbl)
-	tbl[ROLE_SHINIGAMI] = tbl[ROLE_SHINIGAMI] or {}
-
-	table.insert(tbl[ROLE_SHINIGAMI], {
-		cvar = "ttt2_shinigami_announcement",
-		checkbox = true,
-		desc = "Announce when a shinigami is being respawned (Def. 0)"
-	})
-
-	table.insert(tbl[ROLE_SHINIGAMI], {
-		cvar = "ttt2_shinigami_speed",
-		slider = true,
-		min = 0,
-		max = 5,
-		decimal = 2,
-		desc = "Shinigami speed multiplier (Def: 2.00)"}
-	)
-
-	table.insert(tbl[ROLE_SHINIGAMI], {
-		cvar = "ttt2_shinigami_health_loss",
-		slider = true,
-		min = 0,
-		max = 100,
-		decimal = 0,
-		desc = "DPS for the Shinigami, when respawned (Def: 5)"}
-	)
-end)
-
-if SERVER then
+	-- ConVars
 	local shini_announcement = CreateConVar("ttt2_shinigami_announcement", "0", {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "Announce the shinigami being respawned (Def: 0)")
 	local shini_speed = CreateConVar("ttt2_shinigami_speed", "2", {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "The speed the shinigami has when he respawns (Def: 2)")
 	local shini_health_loss = CreateConVar("ttt2_shinigami_health_loss", "5", {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "The amount of damage the shinigami receives every second after he respawns (Def: 5)")
+	local shini_needs_corpse = CreateConVar("ttt2_shini_needs_corpse", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED}, "If the shinigami needs a corpse to revive (Def: 0)")
+	local shini_allow_key_respawn = CreateConVar("ttt2_shini_allow_key_respawn", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED}, "If the shinigami is able to select where to respawn (Def: 1)")
+	local shini_revive_time = CreateConVar("ttt2_shini_revive_time", 3, {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED}, "The time it takes for the shinigami to revive (Def: 3)", 0, 10)
 
-	local function ResetShinigami()
-		for _, ply in ipairs(player.GetAll()) do
-			ply:SetNWBool("SpawnedAsShinigami", false)
-		end
-	end
-
-	hook.Add("TTT2SyncGlobals", "AddShinigamiGlobals", function()
-		SetGlobalFloat(shini_speed:GetName(), shini_speed:GetFloat())
-		SetGlobalFloat(shini_health_loss:GetName(), shini_health_loss:GetFloat())
-	end)
-
+	-- ConVar Callbacks
 	cvars.AddChangeCallback(shini_speed:GetName(), function(name, old, new)
 		SetGlobalFloat(name, new)
 	end, "TTT2ShiniSpeedChange")
@@ -90,6 +93,64 @@ if SERVER then
 	cvars.AddChangeCallback(shini_health_loss:GetName(), function(name, old, new)
 		SetGlobalFloat(name, new)
 	end, "TTT2ShiniHealthLossChange")
+
+	-- Util functions
+	local function SpawnAsShinigami(ply)
+		-- reset confirm Shini player, in case their body was confirmed
+		ply:ResetConfirmPlayer()
+
+		ply:StripWeapons()
+		ply:GiveEquipmentWeapon("weapon_ttt_shinigamiknife")
+		ply:SetNWBool("SpawnedAsShinigami", true)
+
+		SendFullStateUpdate()
+
+		-- NOTIFY ALL PLAYERS THAT THE SHINIGAMI HAS RESPAWNED
+		if shini_announcement:GetBool() then
+			LANG.MsgAll("ttt2_role_shinigami_info_spawned", nil, MSG_MSTACK_WARN)
+		end
+	end
+
+	local function ResetShinigami()
+		for _, ply in ipairs(player.GetAll()) do
+			ply:SetNWBool("SpawnedAsShinigami", false)
+		end
+	end
+
+	-- Network listeners
+	net.Receive("ttt_shini_key_respawn", function(len, ply)
+		-- Only run this function if the player is alive,
+		-- the ConVar is enabled and the player is not already a revived Shinigami
+		if not IsValid(ply) or ply:IsTerror() or shini_allow_key_respawn:GetBool() ~= true then return end
+		if ply:GetNWBool("SpawnedAsShinigami", false) or ply:GetSubRole() ~= ROLE_SHINIGAMI then return end
+
+		local respawnAtCorpse = net.ReadBool()
+		local spawnPosition = {pos = nil, ang = nil}
+
+		if not respawnAtCorpse then
+			spawnPosition = plyspawn.GetRandomSafePlayerSpawnPoint(ply)
+		end
+
+		ply:CancelRevival(nil, true)
+		ply:SendRevivalReason(nil)
+
+		ply:Revive(
+			0, -- reviveTime
+			SpawnAsShinigami,
+			nil, -- doCheck
+			shini_needs_corpse:GetBool(), -- needsCorpse
+			REVIVAL_BLOCK_AS_ALIVE, -- blockRound
+			nil, -- onFail
+			spawnPosition.pos, -- spawnPos
+			spawnPosition.ang -- spawnEyeAngle
+		)
+	end)
+
+	-- Hooks
+	hook.Add("TTT2SyncGlobals", "AddShinigamiGlobals", function()
+		SetGlobalFloat(shini_speed:GetName(), shini_speed:GetFloat())
+		SetGlobalFloat(shini_health_loss:GetName(), shini_health_loss:GetFloat())
+	end)
 
 	hook.Add("TTTEndRound", "ResetShinigami", ResetShinigami)
 	hook.Add("TTTPrepareRound", "ResetShinigami", ResetShinigami)
@@ -100,31 +161,25 @@ if SERVER then
 
 	hook.Add("TTT2PostPlayerDeath", "OnShinigamiDeath", function(victim, inflictor, attacker)
 		if victim:GetSubRole() == ROLE_SHINIGAMI and not victim:GetNWBool("SpawnedAsShinigami") and not victim.reviving then
-			-- revive after 3s
-			victim:Revive(3,
-				function(p) -- this is a TTT2 function that will handle everything else
-					-- reset confirm Shini player, in case their body was confirmed
-					p:ResetConfirmPlayer()
-
-					p:StripWeapons()
-					p:GiveEquipmentWeapon("weapon_ttt_shinigamiknife")
-					p:SetNWBool("SpawnedAsShinigami", true)
-
-					SendFullStateUpdate()
-
-					-- NOTIFY ALL PLAYERS THAT THE SHINIGAMI HAS RESPAWNED
-					if shini_announcement:GetBool() then
-						LANG.MsgAll("ttt2_role_shinigami_info_spawned", nil, MSG_MSTACK_WARN)
-					end
-				end,
+			-- revive after specified time
+			victim:Revive(
+				shini_revive_time:GetInt(),
+				SpawnAsShinigami,
 				function(p) -- onCheck
 					return p:GetSubRole() == ROLE_SHINIGAMI
 				end,
-				false, REVIVAL_BLOCK_AS_ALIVE, -- there need to be the corpse and the round end has to be prevented
+				shini_needs_corpse:GetBool(),
+				REVIVAL_BLOCK_AS_ALIVE, -- there need to be the corpse and the round end has to be prevented
 				nil
 			)
 
-			victim:SendRevivalReason("ttt2_shinigami_revive")
+			-- Tell the client to show keybinds if player is able to select spawn
+			if shini_allow_key_respawn:GetBool() == true then
+				net.Start("ttt_shini_show_reason")
+				net.Send(victim)
+			else
+				victim:SendRevivalReason("ttt2_shinigami_revive")
+			end
 		end
 	end)
 
@@ -183,6 +238,14 @@ if SERVER then
 		return false
 	end)
 
+	hook.Add("TTT2AvoidLastWords", "TTT2ModifyGeneralChat4Shini", function(ply, text)
+		if not IsValid(ply) or ply:GetSubRole() ~= ROLE_SHINIGAMI or not ply:GetNWBool("SpawnedAsShinigami") then return end
+
+		LANG.Msg(ply, "ttt2_shinigami_chat_jammed", nil, MSG_CHAT_WARN)
+
+		return false
+	end)
+
 	hook.Add("TTTOnCorpseCreated", "ModifyShiniRagdoll", function(rag, ply)
 		if not IsValid(ply) or not IsValid(rag) or ply:GetSubRole() ~= ROLE_SHINIGAMI or ply:GetNWBool("SpawnedAsShinigami") then return end
 
@@ -198,6 +261,73 @@ if SERVER then
 		end
 	end)
 end
+
+-- Shared
+
+-- Role functions
+function ROLE:PreInitialize()
+	self.color = Color(200, 200, 200, 255)
+
+	self.abbr = "shini"
+	self.score.killsMultiplier = 2
+	self.score.teamKillsMultiplier = -8
+	self.unknownTeam = true
+	self.disableSync = true
+
+	self.defaultTeam = TEAM_INNOCENT
+	self.defaultEquipment = INNO_EQUIPMENT
+
+	self.conVarData = {
+		pct = 0.15,
+		maximum = 1,
+		minPlayers = 6,
+		credits = 0,
+		togglable = false,
+		random = 50
+	}
+end
+
+function ROLE:Initialize()
+	roles.SetBaseRole(self, ROLE_INNOCENT)
+end
+
+function ROLE:RemoveRoleLoadout(ply, isRoleChange)
+	-- give back normal player loadout
+	ply:GiveEquipmentWeapon("weapon_zm_improvised")
+	ply:GiveEquipmentWeapon("weapon_zm_carry")
+	ply:GiveEquipmentWeapon("weapon_ttt_unarmed")
+
+	ply:StripWeapon("weapon_ttt_shinigamiknife")
+end
+
+-- Hooks
+hook.Add("TTTUlxDynamicRCVars", "TTTUlxDynamicShiniCVars", function(tbl)
+	tbl[ROLE_SHINIGAMI] = tbl[ROLE_SHINIGAMI] or {}
+
+	table.insert(tbl[ROLE_SHINIGAMI], {
+		cvar = "ttt2_shinigami_announcement",
+		checkbox = true,
+		desc = "Announce when a shinigami is being respawned (Def. 0)"
+	})
+
+	table.insert(tbl[ROLE_SHINIGAMI], {
+		cvar = "ttt2_shinigami_speed",
+		slider = true,
+		min = 0,
+		max = 5,
+		decimal = 2,
+		desc = "Shinigami speed multiplier (Def: 2.00)"}
+	)
+
+	table.insert(tbl[ROLE_SHINIGAMI], {
+		cvar = "ttt2_shinigami_health_loss",
+		slider = true,
+		min = 0,
+		max = 100,
+		decimal = 0,
+		desc = "DPS for the Shinigami, when respawned (Def: 5)"}
+	)
+end)
 
 hook.Add("TTTPlayerSpeedModifier", "ShinigamiModifySpeed", function(ply, _, _, noLag)
 	if not IsValid(ply) or not ply:GetNWBool("SpawnedAsShinigami") or ply:GetSubRole() ~= ROLE_SHINIGAMI then return end
@@ -216,31 +346,3 @@ hook.Add("TTT2ClientRadioCommand", "TTT2ModifyQuickChat4Shini", function()
 		return true
 	end
 end)
-
-
-if CLIENT then
-	function ROLE:AddToSettingsMenu(parent)
-		local form = vgui.CreateTTT2Form(parent, "header_roles_additional")
-
-		form:MakeCheckBox({
-			serverConvar = "ttt2_shinigami_announcement",
-			label = "label_shinigami_announcement"
-		})
-
-		form:MakeSlider({
-			serverConvar = "ttt2_shinigami_speed",
-			label = "label_shinigami_speed",
-			min = 0,
-			max = 5,
-			decimal = 2
-		})
-
-		form:MakeSlider({
-			serverConvar = "ttt2_shinigami_health_loss",
-			label = "label_shinigami_health_loss",
-			min = 0,
-			max = 100,
-			decimal = 0
-		})
-	end
-end

--- a/lua/terrortown/lang/de/shinigami.lua
+++ b/lua/terrortown/lang/de/shinigami.lua
@@ -10,6 +10,12 @@ L["ttt2_desc_" .. SHINIGAMI.name] = [[Der Shinigami ist ein Innocent (der mit de
 L["ttt2_shinigami_chat_jammed"] = "Der Chat ist blockiert! Du kannst den Chat als ein neu Gespawnter Shinigami nicht verwenden."
 L["ttt2_shinigami_revive"] = "Du wirst als ein Shinigami wiederbelebt. Nimm dein Messer, sei leise und töte diese nervigen Verräter!"
 L["ttt2_role_shinigami_info_spawned"] = "Ein Shinigami ist auferstanden und sucht nach den Verrätern!"
+L["label_shinigami_needs_corpse"] = "Braucht der Shinigami eine Leiche um wiederbelebt zu werden?"
+L["label_shinigami_allow_key_respawn"] = "Soll der Shinigami seinen Spawn aussuchen können?"
+L["label_shinigami_revive_time"] = "Die Zeit bis der Shinigami wiederbelebt wird."
 L["label_shinigami_announcement"] = "Soll allen Mitspielern eine Ankündigung angezeigt werden, wenn er wiederbelebt wird?"
 L["label_shinigami_speed"] = "Geschwindikeitsmultiplikator wenn der Shinigami aktiv ist."
 L["label_shinigami_health_loss"] = "Schaden pro Sekunde den der Shinigami nach dem Wiederbeleben erhält."
+L["ttt2_shinigami_revive_keys"] = [[Du wirst als ein Shinigami wiederbelebt. Nimm dein Messer, sei leise und töte diese nervigen Verräter!
+
+Drücke {keycorpse} um an deiner Leiche wiederbelebt zu werden. Drücke {keyspawn} um am Spawn wiederbelebt zu werden.]]

--- a/lua/terrortown/lang/en/shinigami.lua
+++ b/lua/terrortown/lang/en/shinigami.lua
@@ -10,6 +10,12 @@ L["ttt2_desc_" .. SHINIGAMI.name] = [[The Shinigami is an Innocent (who works to
 L["ttt2_shinigami_chat_jammed"] = "The Chat is jammed! You can't use the chat as a respawned Shinigami."
 L["ttt2_shinigami_revive"] = "You are revived as a Shinigami. Take your knife, be quiet and kill those pesky Traitors!"
 L["ttt2_role_shinigami_info_spawned"] = "A Shinigami was resurrected and is on the hunt for Traitors!"
+L["label_shinigami_needs_corpse"] = "Does the Shinigami need a corpse to revive?"
+L["label_shinigami_allow_key_respawn"] = "Should the Shinigami be able to select their spawn?"
+L["label_shinigami_revive_time"] = "Revive time for the Shinigami."
 L["label_shinigami_announcement"] = "Should the Shinigami be announced to everyone once he respawns?"
 L["label_shinigami_speed"] = "Speed multiplier for the Shinigami after he respawned."
 L["label_shinigami_health_loss"] = "Damage per second, that the Shinigami receives after being respawned."
+L["ttt2_shinigami_revive_keys"] = [[You are revived as a Shinigami. Take your knife, be quiet and kill those pesky Traitors!
+
+Press {keycorpse} to respawn at your corpse. Press {keyspawn} to respawn at spawn.]]


### PR DESCRIPTION
# References
- Fixes #26
- Partially implements features from #8 

# What exactly I've done
- restructured file layout (clear seperation of client, server and shared code)
  - I've originally used seperate files, but it seems like common practice to only use one file (as seen in most role repos)
- ~~added new Hook AvoidLastWords to block last words if player dies as a respawned Shinigami~~ (uses new hook "TTTLastWordsMsg")
- Added spawn selection for Shinigami
  - Default: R (at corpse), SPACE (at world-spawn)
- Added new ConVars:
  - `shinigami_needs_corpse`: if the Shinigami should only be revived if they have a corpse
  - `shinigami_allow_key_respawn`: if the Shinigami should be able to select their respawn-point
  - `shinigami_revive_time`: the time it takes the shinigami to revive (if either they don't select a spawn or spawn selection is disabled)

# Testing
I've already tested most logic, though we'll test it in a proper round tomorrow with the following settings:
- needs corpse: false
- allow key respawn: true
- revive_time: 3